### PR TITLE
Fix example for 'greater than'.

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -291,7 +291,7 @@ Oh also provides a set of relational operators:
 
     echo "3 is equal to 2 =>": eq 3 2
     echo "3 is greater than or equal to 2 =>": ge 3 2
-    echo "3 is greater than 2 =>": ge 3 2
+    echo "3 is greater than 2 =>": gt 3 2
     echo "3 is less than or equal to 2 =>": le 3 2
     echo "3 is less than 2 =>": lt 3 2
     echo "3 is not equal to 2 =>": ne 3 2


### PR DESCRIPTION
`echo "3 is greater than 2 =>": ge 3 2` is incorrect; should be `gt 3 2`