### PR TITLE
Support -i flag, use flags package

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,28 +306,26 @@ func split(s string) (head, tail string) {
 
 func main() {
 	defer task.Exit()
-	ohFlags := flag.NewFlagSet("oh", flag.ContinueOnError)
 
-	interactive := ohFlags.Bool("i", true, "enable interactive mode")
-	command := ohFlags.Bool("c", false, "parses next args as a command to execute")
+	interactive := flag.Bool("i", true, "enable interactive mode")
+	command := flag.String("c", "", "run a shell command")
 
-	err := ohFlags.Parse(os.Args[1:])
-	if err != nil {
+	flag.Parse()
+
+	if *command != "" {
+		task.StartNonInteractive(*command, flag.Args())
 		return
 	}
 
-	if *command {
-		*interactive = false
-	}
-
-	if ohFlags.NArg() > 0 {
-		task.StartNonInteractive(*command, append([]string{os.Args[0]}, ohFlags.Args()...))
-		return
-	}
-
-	if !*interactive {
+	if !*interactive && *command == "" {
 		fmt.Println("Non interactive session needs either a command (-c) or a file as argument")
-		ohFlags.Usage()
+		flag.Usage()
+		return
+	}
+
+	if flag.NArg() > 0 {
+		args := flag.Args()
+		task.StartFile(filepath.Dir(args[1]), args[1:])
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -304,7 +304,9 @@ func split(s string) (head, tail string) {
 	return
 }
 
-func options() {
+func main() {
+	defer task.Exit()
+
 	interactive := flag.Bool("i", true, "enable interactive mode")
 	command := flag.String("c", "", "parse next argument instead of stdin")
 
@@ -326,12 +328,6 @@ func options() {
 		task.StartFile(filepath.Dir(args[1]), args[1:])
 		return
 	}
-}
-
-func main() {
-	defer task.Exit()
-
-	options()
 
 	// We assume the terminal starts in cooked mode.
 	cooked, _ = liner.TerminalMode()

--- a/main.go
+++ b/main.go
@@ -23,15 +23,18 @@ Oh is released under an MIT license.
 package main
 
 import (
-	"github.com/michaelmacinnis/oh/pkg/cell"
-	"github.com/michaelmacinnis/oh/pkg/system"
-	"github.com/michaelmacinnis/oh/pkg/task"
-	"github.com/peterh/liner"
+	"flag"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/michaelmacinnis/oh/pkg/cell"
+	"github.com/michaelmacinnis/oh/pkg/system"
+	"github.com/michaelmacinnis/oh/pkg/task"
+	"github.com/peterh/liner"
 )
 
 type ui struct {
@@ -304,9 +307,28 @@ func split(s string) (head, tail string) {
 
 func main() {
 	defer task.Exit()
+	ohFlags := flag.NewFlagSet("oh", flag.ContinueOnError)
 
-	if len(os.Args) > 1 {
-		task.StartNonInteractive()
+	interactive := ohFlags.Bool("i", true, "enable interactive mode")
+	command := ohFlags.Bool("c", false, "parses next args as a command to execute")
+
+	err := ohFlags.Parse(os.Args[1:])
+	if err != nil {
+		return
+	}
+
+	if *command {
+		*interactive = false
+	}
+
+	if ohFlags.NArg() > 0 {
+		task.StartNonInteractive(*command, append([]string{os.Args[0]}, ohFlags.Args()...))
+		return
+	}
+
+	if !*interactive {
+		fmt.Println("Non interactive session needs either a command (-c) or a file as argument")
+		ohFlags.Usage()
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -304,11 +304,9 @@ func split(s string) (head, tail string) {
 	return
 }
 
-func main() {
-	defer task.Exit()
-
+func options() {
 	interactive := flag.Bool("i", true, "enable interactive mode")
-	command := flag.String("c", "", "run a shell command")
+	command := flag.String("c", "", "parse next argument instead of stdin")
 
 	flag.Parse()
 
@@ -328,6 +326,12 @@ func main() {
 		task.StartFile(filepath.Dir(args[1]), args[1:])
 		return
 	}
+}
+
+func main() {
+	defer task.Exit()
+
+	options()
 
 	// We assume the terminal starts in cooked mode.
 	cooked, _ = liner.TerminalMode()

--- a/main.go
+++ b/main.go
@@ -25,16 +25,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/michaelmacinnis/oh/pkg/cell"
+	"github.com/michaelmacinnis/oh/pkg/system"
+	"github.com/michaelmacinnis/oh/pkg/task"
+	"github.com/peterh/liner"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/michaelmacinnis/oh/pkg/cell"
-	"github.com/michaelmacinnis/oh/pkg/system"
-	"github.com/michaelmacinnis/oh/pkg/task"
-	"github.com/peterh/liner"
 )
 
 type ui struct {

--- a/main.go
+++ b/main.go
@@ -324,8 +324,7 @@ func main() {
 	}
 
 	if flag.NArg() > 0 {
-		args := flag.Args()
-		task.StartFile(filepath.Dir(args[1]), args[1:])
+		task.StartFile(filepath.Dir(os.Args[1]), os.Args[1:])
 		return
 	}
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -1751,15 +1751,11 @@ func StartInteractive(p Parser) {
 	p.ParseCommands("oh", evaluate)
 }
 
-func StartNonInteractive(command bool, args []string) {
-	if command {
-		bindSpecialVariables("", args)
+func StartNonInteractive(command string, args []string) {
+	bindSpecialVariables("", args)
 
-		b := bufio.NewReader(strings.NewReader(args[1] + "\n"))
-		MakeParser(b.ReadString).ParseBuffer(false, "-c", eval)
-	} else {
-		StartFile(filepath.Dir(args[1]), args[1:])
-	}
+	b := bufio.NewReader(strings.NewReader(command + "\n"))
+	MakeParser(b.ReadString).ParseBuffer(false, "-c", eval)
 }
 
 func bindSpecialVariables(origin string, args []string) {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -5,6 +5,12 @@ package task
 import (
 	"bufio"
 	"fmt"
+	"github.com/michaelmacinnis/adapted"
+	"github.com/michaelmacinnis/oh/pkg/boot"
+	. "github.com/michaelmacinnis/oh/pkg/cell"
+	"github.com/michaelmacinnis/oh/pkg/parser"
+	"github.com/michaelmacinnis/oh/pkg/system"
+	"github.com/peterh/liner"
 	"math/rand"
 	"os"
 	"path"
@@ -15,13 +21,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/michaelmacinnis/adapted"
-	"github.com/michaelmacinnis/oh/pkg/boot"
-	. "github.com/michaelmacinnis/oh/pkg/cell"
-	"github.com/michaelmacinnis/oh/pkg/parser"
-	"github.com/michaelmacinnis/oh/pkg/system"
-	"github.com/peterh/liner"
 )
 
 type binding interface {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -5,12 +5,6 @@ package task
 import (
 	"bufio"
 	"fmt"
-	"github.com/michaelmacinnis/adapted"
-	"github.com/michaelmacinnis/oh/pkg/boot"
-	. "github.com/michaelmacinnis/oh/pkg/cell"
-	"github.com/michaelmacinnis/oh/pkg/parser"
-	"github.com/michaelmacinnis/oh/pkg/system"
-	"github.com/peterh/liner"
 	"math/rand"
 	"os"
 	"path"
@@ -21,6 +15,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/michaelmacinnis/adapted"
+	"github.com/michaelmacinnis/oh/pkg/boot"
+	. "github.com/michaelmacinnis/oh/pkg/cell"
+	"github.com/michaelmacinnis/oh/pkg/parser"
+	"github.com/michaelmacinnis/oh/pkg/system"
+	"github.com/peterh/liner"
 )
 
 type binding interface {
@@ -1751,21 +1752,14 @@ func StartInteractive(p Parser) {
 	p.ParseCommands("oh", evaluate)
 }
 
-func StartNonInteractive() {
-	if os.Args[1] == "-c" {
-		if len(os.Args) == 2 {
-			msg := "-c requires an argument"
-			println(ErrSyntax + msg)
-			os.Exit(1)
-		}
-
-		args := append([]string{os.Args[0]}, os.Args[3:]...)
+func StartNonInteractive(command bool, args []string) {
+	if command {
 		bindSpecialVariables("", args)
 
-		b := bufio.NewReader(strings.NewReader(os.Args[2] + "\n"))
+		b := bufio.NewReader(strings.NewReader(args[1] + "\n"))
 		MakeParser(b.ReadString).ParseBuffer(false, "-c", eval)
 	} else {
-		StartFile(filepath.Dir(os.Args[1]), os.Args[1:])
+		StartFile(filepath.Dir(args[1]), args[1:])
 	}
 }
 


### PR DESCRIPTION
Add flag -i to be compatible with the posix flag, which is expected by some programs invoking embedded shells in terminals. Also manage flags with the standard package.

As per #39 .