### PR TITLE
Adding `kill` built-in command in order to support job control.

### DIFF
--- a/internal/system/job/job_unix.go
+++ b/internal/system/job/job_unix.go
@@ -332,6 +332,22 @@ func Jobs(w io.Writer) {
 	<-r
 }
 
+func Getpgid(n int) int {
+	r := make(chan int)
+
+	requestq <- func() {
+		job, ok := jobs[n]
+		if ok {
+			r <- job.group
+		} else {
+			r <- 0
+		}
+		close(r)
+	}
+
+	return <-r
+}
+
 // Monitor launches the goroutine responsible for monitoring jobs/tasks.
 func Monitor() {
 	signals := []os.Signal{unix.SIGCHLD}


### PR DESCRIPTION
Internal kill replaces jobs ids with the corresponding process
group ids and executes kill binary.

For example:

```
kill %1       -> kill -- -123
kill %1 %3    -> kill -- -123 -154
kill -9 %1    -> kill -9 -123
kill -TERM %1 -> kill -TERM -123
```

Please, let me know if you want such  or any changes. 
If yes, I'm ready to work on it and update this PR. 
If not, thank you for your work, I was learning how shells work and found your project. It helped me with understanding some internals.  