### PR TITLE
Fix go.mod `go` format for `go install`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/michaelmacinnis/oh
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815


### PR DESCRIPTION
Using the instructions results in:

```
$ go install github.com/michaelmacinnis/oh@v0.8.3
go: github.com/michaelmacinnis/oh@v0.8.3 (in github.com/michaelmacinnis/oh@v0.8.3): go.mod:3: invalid go version '1.21.0': must match format 1.23
```

It seems (not being a Go dev in any way, shape or form) that what was specified is a "language version" and not a "release version" required by the file.

https://go.dev/doc/toolchain#version
https://go.dev/ref/mod#go-mod-file

This just changes the format to 1.21. However I can't really test it very easily because go install really doesn't play nice with forks and the module path.